### PR TITLE
Add preview-safe dashboard and harden real-host diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Build outputs
+build/
+build_on/
+build_off/
+CMakeCache.txt
+CMakeFiles/
+Testing/
+
+# UI build artifacts
+ui/dist/
+ui/build/
+
+# Python
+__pycache__/
+*.pyc
+.venv/

--- a/python/engine_ui/__init__.py
+++ b/python/engine_ui/__init__.py
@@ -1,0 +1,1 @@
+"""UI support modules for engine output visualization."""

--- a/python/engine_ui/resource_locator.py
+++ b/python/engine_ui/resource_locator.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ResourceLocator:
+    """Resolve engine-related resource paths from a single root."""
+
+    engine_root: Path
+
+    @classmethod
+    def from_env(cls, env_var: str = "ENGINE_ROOT", default_root: Optional[Path] = None) -> "ResourceLocator":
+        """Create a locator using an optional environment override."""
+        if default_root is None:
+            default_root = Path.cwd()
+        engine_root = Path(default_root)
+        # Use os.environ directly to avoid optional imports in module scope.
+        import os
+
+        env_value = os.environ.get(env_var)
+        if env_value:
+            engine_root = Path(env_value)
+        return cls(engine_root=engine_root.resolve())
+
+    def resolve(self, relative_path: str | Path) -> Path:
+        """Resolve a relative resource path from the engine root."""
+        candidate = Path(relative_path)
+        if candidate.is_absolute():
+            return candidate
+        return (self.engine_root / candidate).resolve()
+
+    def schema_path(self) -> Path:
+        return self.resolve("schemas/engine_output.schema.json")
+
+    def output_path(self, output_relative_path: str | Path) -> Path:
+        return self.resolve(output_relative_path)

--- a/python/engine_ui/schema_validation.py
+++ b/python/engine_ui/schema_validation.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+import importlib
+import importlib.util
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, List
+
+
+@dataclass
+class ValidationResult:
+    is_valid: bool
+    errors: List[str]
+
+    @property
+    def missing_fields(self) -> List[str]:
+        missing = []
+        for error in self.errors:
+            if "is a required property" in error:
+                missing.append(error.split("'")[1])
+        return sorted(set(missing))
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validate_payload(payload: Any, schema: Any) -> ValidationResult:
+    if importlib.util.find_spec("jsonschema"):
+        jsonschema = importlib.import_module("jsonschema")
+        validator = jsonschema.Draft202012Validator(schema)
+        errors = sorted(validator.iter_errors(payload), key=lambda err: err.path)
+        formatted = [format_error(error) for error in errors]
+        return ValidationResult(is_valid=not formatted, errors=formatted)
+    formatted = basic_validate(payload, schema)
+    return ValidationResult(is_valid=not formatted, errors=formatted)
+
+
+def format_error(error) -> str:
+    path = "/".join(str(item) for item in error.path) or "<root>"
+    return f"{path}: {error.message}"
+
+
+def basic_validate(payload: Any, schema: Any) -> List[str]:
+    errors: List[str] = []
+    _validate_against_schema(payload, schema, errors, path="<root>")
+    return errors
+
+
+def _validate_against_schema(value: Any, schema: Any, errors: List[str], path: str) -> None:
+    expected_type = schema.get("type")
+    if expected_type:
+        if not _matches_type(value, expected_type):
+            errors.append(f"{path}: expected {expected_type} but got {type(value).__name__}")
+            return
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        for field in required:
+            if field not in value:
+                errors.append(f"{path}: '{field}' is a required property")
+
+        properties = schema.get("properties", {})
+        for key, subschema in properties.items():
+            if key in value:
+                _validate_against_schema(value[key], subschema, errors, path=f"{path}/{key}")
+
+        if schema.get("additionalProperties") is False:
+            extra = set(value.keys()) - set(properties.keys())
+            for key in sorted(extra):
+                errors.append(f"{path}: additional property '{key}' is not allowed")
+
+    if isinstance(value, list):
+        items_schema = schema.get("items")
+        if items_schema:
+            for idx, item in enumerate(value):
+                _validate_against_schema(item, items_schema, errors, path=f"{path}/{idx}")
+
+
+def _matches_type(value: Any, expected_type: str) -> bool:
+    if expected_type == "object":
+        return isinstance(value, dict)
+    if expected_type == "array":
+        return isinstance(value, list)
+    if expected_type == "string":
+        return isinstance(value, str)
+    if expected_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected_type == "boolean":
+        return isinstance(value, bool)
+    return True
+
+
+def validate_payload_file(payload_path: Path, schema_path: Path) -> ValidationResult:
+    payload = load_json(payload_path)
+    schema = load_json(schema_path)
+    return validate_payload(payload, schema)
+
+
+def summarize_errors(errors: Iterable[str]) -> str:
+    if not errors:
+        return "Validation passed."
+    return "Validation failed:\n" + "\n".join(f"- {error}" for error in errors)

--- a/python/tests/fixtures/invalid_engine_output.json
+++ b/python/tests/fixtures/invalid_engine_output.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "1.0.0",
+  "generated_at": "2026-01-01T22:05:00Z",
+  "determinism": {
+    "is_deterministic": true,
+    "markers": []
+  },
+  "engine": {
+    "name": "DARK leaf drone",
+    "version": "4.1.0"
+  },
+  "summary": {
+    "status": "complete",
+    "score": 88.7
+  },
+  "artifacts": {
+    "report_path": "reports/run-2026-01-01-0002/report.json",
+    "metrics_path": "reports/run-2026-01-01-0002/metrics.json"
+  }
+}

--- a/python/tests/fixtures/valid_engine_output.json
+++ b/python/tests/fixtures/valid_engine_output.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0.0",
+  "run_id": "run-2026-01-01-0002",
+  "generated_at": "2026-01-01T22:05:00Z",
+  "determinism": {
+    "is_deterministic": true,
+    "markers": ["fixed_seed"]
+  },
+  "engine": {
+    "name": "DARK leaf drone",
+    "version": "4.1.0"
+  },
+  "summary": {
+    "status": "complete",
+    "score": 88.7,
+    "notes": "Stable run."
+  },
+  "metrics": {
+    "energy_consumption": 11.2,
+    "hover_efficiency": 0.93,
+    "flight_time": 40.0
+  },
+  "artifacts": {
+    "report_path": "reports/run-2026-01-01-0002/report.json",
+    "metrics_path": "reports/run-2026-01-01-0002/metrics.json"
+  }
+}

--- a/python/tests/test_render_report.py
+++ b/python/tests/test_render_report.py
@@ -1,0 +1,27 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from engine_ui.schema_validation import validate_payload_file
+from tools.render_daily_dashboard import render_report
+
+
+class RenderReportTests(unittest.TestCase):
+    def test_report_contains_sentinels(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        schema_path = repo_root / "schemas" / "engine_output.schema.json"
+        payload_path = repo_root / "python" / "tests" / "fixtures" / "valid_engine_output.json"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "report.html"
+            render_report(payload_path, schema_path, output_path)
+            contents = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("Daily Dashboard Report", contents)
+        self.assertIn("Validation: PASS", contents)
+        result = validate_payload_file(payload_path, schema_path)
+        self.assertTrue(result.is_valid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_resource_locator.py
+++ b/python/tests/test_resource_locator.py
@@ -1,0 +1,29 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from engine_ui.resource_locator import ResourceLocator
+
+
+class ResourceLocatorTests(unittest.TestCase):
+    def test_resolve_relative_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            locator = ResourceLocator(engine_root=Path(tmpdir))
+            resolved = locator.resolve("schemas/engine_output.schema.json")
+            self.assertEqual(resolved, Path(tmpdir) / "schemas/engine_output.schema.json")
+
+    def test_env_override(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ["ENGINE_ROOT"] = tmpdir
+            locator = ResourceLocator.from_env(default_root=Path("/fallback"))
+            self.assertEqual(locator.engine_root, Path(tmpdir).resolve())
+        os.environ.pop("ENGINE_ROOT", None)
+
+    def test_schema_path(self):
+        locator = ResourceLocator(engine_root=Path("/tmp"))
+        self.assertEqual(locator.schema_path(), Path("/tmp/schemas/engine_output.schema.json"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_schema_validation.py
+++ b/python/tests/test_schema_validation.py
@@ -1,0 +1,26 @@
+import unittest
+from pathlib import Path
+
+from engine_ui.schema_validation import validate_payload_file
+
+
+class SchemaValidationTests(unittest.TestCase):
+    def setUp(self):
+        self.repo_root = Path(__file__).resolve().parents[2]
+        self.schema_path = self.repo_root / "schemas" / "engine_output.schema.json"
+        self.valid_payload = self.repo_root / "python" / "tests" / "fixtures" / "valid_engine_output.json"
+        self.invalid_payload = self.repo_root / "python" / "tests" / "fixtures" / "invalid_engine_output.json"
+
+    def test_valid_payload(self):
+        result = validate_payload_file(self.valid_payload, self.schema_path)
+        self.assertTrue(result.is_valid)
+        self.assertEqual(result.errors, [])
+
+    def test_invalid_payload(self):
+        result = validate_payload_file(self.invalid_payload, self.schema_path)
+        self.assertFalse(result.is_valid)
+        self.assertIn("run_id", result.missing_fields)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tools/__init__.py
+++ b/python/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line tooling for the Daily Dashboard UI."""

--- a/python/tools/render_daily_dashboard.py
+++ b/python/tools/render_daily_dashboard.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from engine_ui.schema_validation import summarize_errors, validate_payload_file
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render a static Daily Dashboard report.")
+    parser.add_argument("payload", type=Path, help="Path to engine output JSON payload.")
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=Path("schemas/engine_output.schema.json"),
+        help="Path to engine output schema.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("ui/daily_dashboard_report.html"),
+        help="Output HTML file path.",
+    )
+    return parser.parse_args()
+
+
+def render_report(payload_path: Path, schema_path: Path, output_path: Path) -> None:
+    result = validate_payload_file(payload_path, schema_path)
+    payload = payload_path.read_text(encoding="utf-8")
+    summary = "PASS" if result.is_valid else "FAIL"
+
+    error_list = "\n".join(f"<li>{error}</li>" for error in result.errors) or "<li>No errors.</li>"
+
+    html = f"""<!doctype html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"utf-8\" />
+    <title>Daily Dashboard Report</title>
+    <style>
+      body {{ font-family: system-ui, sans-serif; margin: 24px; background: #f6f7fb; color: #18212f; }}
+      .card {{ background: #fff; border-radius: 12px; padding: 16px; box-shadow: 0 12px 24px rgba(15,23,42,0.08); }}
+      .status.pass {{ color: #15803d; font-weight: 700; }}
+      .status.fail {{ color: #b91c1c; font-weight: 700; }}
+      pre {{ background: #f4f6fa; padding: 12px; border-radius: 8px; overflow-x: auto; }}
+    </style>
+  </head>
+  <body>
+    <h1>Daily Dashboard Report</h1>
+    <p class=\"status {summary.lower()}\">Validation: {summary}</p>
+    <div class=\"card\">
+      <h2>Validation Summary</h2>
+      <p>{summarize_errors(result.errors)}</p>
+      <ul>{error_list}</ul>
+    </div>
+    <div class=\"card\" style=\"margin-top:16px;\">
+      <h2>Payload</h2>
+      <pre>{payload}</pre>
+    </div>
+  </body>
+</html>
+"""
+
+    output_path.write_text(html, encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    render_report(args.payload, args.schema, args.output)
+    print(f"Report written to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/tools/validate_engine_output.py
+++ b/python/tools/validate_engine_output.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from engine_ui.resource_locator import ResourceLocator
+from engine_ui.schema_validation import summarize_errors, validate_payload_file
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate engine output JSON against the contract schema.")
+    parser.add_argument("payload", type=Path, help="Path to the engine output JSON payload.")
+    parser.add_argument(
+        "--engine-root",
+        type=Path,
+        default=None,
+        help="Optional engine root override. Defaults to cwd or ENGINE_ROOT.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    locator = ResourceLocator.from_env(default_root=args.engine_root)
+    schema_path = locator.schema_path()
+    result = validate_payload_file(args.payload, schema_path)
+    print(summarize_errors(result.errors))
+    if result.missing_fields:
+        print("Missing required fields:")
+        for field in result.missing_fields:
+            print(f"- {field}")
+    return 0 if result.is_valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/schemas/engine_output.schema.json
+++ b/schemas/engine_output.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/engine_output.schema.json",
+  "title": "Drone Engine Output",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "generated_at",
+    "determinism",
+    "engine",
+    "summary",
+    "artifacts"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Schema version for the engine output contract."
+    },
+    "run_id": {
+      "type": "string",
+      "description": "Unique run identifier for the engine execution."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 timestamp for when the output was generated."
+    },
+    "determinism": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["is_deterministic", "markers"],
+      "properties": {
+        "is_deterministic": {
+          "type": "boolean",
+          "description": "Whether the run is deterministic."
+        },
+        "markers": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Determinism markers observed during the run."
+        }
+      }
+    },
+    "engine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": {"type": "string"},
+        "version": {"type": "string"}
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "score"],
+      "properties": {
+        "status": {"type": "string"},
+        "score": {"type": "number"},
+        "notes": {"type": "string"}
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Engine metrics keyed by metric name.",
+      "properties": {
+        "energy_consumption": {"type": "number"},
+        "hover_efficiency": {"type": "number"},
+        "flight_time": {"type": "number"}
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["report_path", "metrics_path"],
+      "properties": {
+        "report_path": {"type": "string"},
+        "metrics_path": {"type": "string"}
+      }
+    }
+  }
+}

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,58 @@
+# Daily Dashboard UI
+
+This UI presents a contract-driven daily dashboard for engine output JSON. It validates payloads against the shared schema and surfaces trust signals (validation state, schema version, run ID, determinism markers, missing fields).
+
+## Requirements
+
+* Python 3 (for the static file server or validation tooling)
+* Network access if you want to load Ajv from the CDN
+
+## Run the UI
+
+If viewing in GitHub PR Preview: open `ui/dashboard_preview.html`.
+
+If running locally:
+
+```bash
+python -m http.server 8000
+```
+
+Then open `http://localhost:8000/ui/dashboard.html` in your browser.
+
+### Load data
+
+* **Sample payload**: Click "Load sample payload" to load `ui/sample_payloads/sample_engine_output.json`.
+* **Invalid payload**: Click "Load invalid payload" to see missing-field diagnostics.
+* **Custom payload**: Use the file picker to load any engine output JSON file.
+
+### Diagnostics and errors
+
+The dashboard prints resolved schema/payload URLs plus fetch status and content-type inside the Diagnostics panel. Any fetch/parse/validation failure renders a full error panel with actionable suggestions.
+
+## Static HTML report (no JS required)
+
+Generate a self-contained HTML report directly from a payload:
+
+```bash
+PYTHONPATH=python python python/tools/render_daily_dashboard.py \
+  ui/sample_payloads/sample_engine_output.json \
+  --output ui/daily_dashboard_report.html
+```
+
+Open `ui/daily_dashboard_report.html` in a browser.
+
+## Validation tooling
+
+The CLI validator uses the same JSON schema.
+
+```bash
+PYTHONPATH=python python python/tools/validate_engine_output.py ui/sample_payloads/sample_engine_output.json
+```
+
+## Trust signals displayed
+
+* Validation pass/fail
+* Schema version
+* Run ID
+* Determinism markers
+* Missing required fields

--- a/ui/dashboard.css
+++ b/ui/dashboard.css
@@ -1,0 +1,128 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  background: #f6f7fb;
+  color: #18212f;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+}
+
+.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+}
+
+.subtitle {
+  margin-top: 8px;
+  color: #4b5565;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.control {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  gap: 6px;
+}
+
+input[type="text"],
+input[type="file"] {
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid #d0d6e0;
+  background: #fff;
+}
+
+.button-row {
+  display: flex;
+  gap: 8px;
+}
+
+button {
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid #1f6feb;
+  background: #1f6feb;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+button.ghost {
+  background: transparent;
+  color: #1f6feb;
+}
+
+.status {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  margin: 24px 0;
+}
+
+.status__card,
+.data__card,
+.errors,
+.error-panel {
+  background: #fff;
+  border-radius: 12px;
+  padding: 16px 20px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.status__card ul {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: grid;
+  gap: 8px;
+}
+
+.data {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.diagnostics {
+  margin: 12px 0 0;
+  padding-left: 18px;
+}
+
+.success {
+  color: #15803d;
+  font-weight: 600;
+}
+
+.failure {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+pre {
+  background: #f4f6fa;
+  padding: 12px;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.error-panel {
+  border: 1px solid #b91c1c;
+  background: #fff5f5;
+  margin-top: 16px;
+}
+
+.app-shell {
+  display: block;
+}

--- a/ui/dashboard.html
+++ b/ui/dashboard.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Daily Dashboard</title>
+    <link rel="stylesheet" href="./dashboard.css" />
+    <style>
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, Segoe UI, sans-serif;
+        background: #f6f7fb;
+        color: #18212f;
+      }
+      main {
+        padding: 24px;
+      }
+      .fallback {
+        background: #fff4e6;
+        border: 1px solid #f7b955;
+        padding: 12px;
+        border-radius: 8px;
+      }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/ajv@8/dist/ajv.min.js" defer></script>
+    <script src="./dashboard.js" defer></script>
+  </head>
+  <body>
+    <main class="page">
+      <h1>Daily Dashboard</h1>
+      <p class="subtitle">Contract-driven view of engine output snapshots.</p>
+      <noscript>
+        <div class="fallback">
+          JavaScript is required to load the schema and payload diagnostics. Start a local server
+          with <code>python -m http.server 8000</code> and open
+          <code>http://localhost:8000/ui/dashboard.html</code>.
+        </div>
+      </noscript>
+      <section id="diagnostics" class="status__card">
+        <h2>Diagnostics</h2>
+        <p>Resolved URLs, fetch status, and error details will appear here.</p>
+      </section>
+      <section id="status" class="status__card">Loading…</section>
+      <main id="app" class="app-shell">
+        <section class="status">
+          <div class="status__card">
+            <h2>Trust Signals</h2>
+            <ul>
+              <li><strong>Validation:</strong> <span id="validationStatus">Awaiting data</span></li>
+              <li><strong>Schema version:</strong> <span id="schemaVersion">—</span></li>
+              <li><strong>Run ID:</strong> <span id="runId">—</span></li>
+              <li><strong>Determinism:</strong> <span id="determinism">—</span></li>
+              <li><strong>Determinism markers:</strong> <span id="markers">—</span></li>
+            </ul>
+          </div>
+          <div class="status__card">
+            <h2>Missing-field diagnostics</h2>
+            <ul id="missingFields" class="diagnostics">
+              <li>No validation results yet.</li>
+            </ul>
+          </div>
+        </section>
+
+        <section class="data">
+          <div class="data__card">
+            <h2>Summary</h2>
+            <div id="summary"></div>
+          </div>
+          <div class="data__card">
+            <h2>Metrics</h2>
+            <div id="metrics"></div>
+          </div>
+          <div class="data__card">
+            <h2>Artifacts</h2>
+            <div id="artifacts"></div>
+          </div>
+        </section>
+
+        <section class="errors">
+          <h2>Validation errors</h2>
+          <ul id="errorList" class="diagnostics">
+            <li>No errors to report.</li>
+          </ul>
+        </section>
+      </main>
+      <section class="status__card controls">
+        <h2>Controls</h2>
+        <label class="control">
+          Load output JSON
+          <input id="payloadFile" type="file" accept="application/json" />
+        </label>
+        <div class="button-row">
+          <button id="loadSample" type="button">Load sample payload</button>
+          <button id="loadInvalid" type="button" class="ghost">Load invalid payload</button>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/ui/dashboard.js
+++ b/ui/dashboard.js
@@ -1,0 +1,312 @@
+const base = new URL('.', window.location.href);
+const schemaUrl = new URL('../schemas/engine_output.schema.json', base);
+const payloadUrl = new URL('./sample_payloads/sample_engine_output.json', base);
+const invalidPayloadUrl = new URL('./sample_payloads/invalid_engine_output.json', base);
+
+const elements = {
+  diagnostics: document.getElementById('diagnostics'),
+  status: document.getElementById('status'),
+  payloadFile: document.getElementById('payloadFile'),
+  loadSample: document.getElementById('loadSample'),
+  loadInvalid: document.getElementById('loadInvalid'),
+  validationStatus: document.getElementById('validationStatus'),
+  schemaVersion: document.getElementById('schemaVersion'),
+  runId: document.getElementById('runId'),
+  determinism: document.getElementById('determinism'),
+  markers: document.getElementById('markers'),
+  missingFields: document.getElementById('missingFields'),
+  summary: document.getElementById('summary'),
+  metrics: document.getElementById('metrics'),
+  artifacts: document.getElementById('artifacts'),
+  errorList: document.getElementById('errorList'),
+};
+
+const state = {
+  schema: null,
+  ajv: null,
+  schemaFetchResult: null,
+};
+
+function updateStatus(message, isValid = false) {
+  elements.status.textContent = message;
+  elements.status.className = `status__card ${isValid ? 'success' : 'failure'}`;
+}
+
+function renderDiagnostics(details) {
+  const schemaResult = details?.schemaFetch ?? state.schemaFetchResult;
+  const lines = [
+    `<strong>Base URL:</strong> ${base.href}`,
+    `<strong>Schema URL:</strong> ${schemaUrl.href}`,
+    `<strong>Sample payload URL:</strong> ${payloadUrl.href}`,
+  ];
+
+  if (schemaResult) {
+    lines.push(renderFetchResult('Schema fetch', schemaResult));
+  }
+  if (details?.payloadFetch) {
+    lines.push(renderFetchResult('Payload fetch', details.payloadFetch));
+  }
+
+  elements.diagnostics.innerHTML = `
+    <h2>Diagnostics</h2>
+    <ul class="diagnostics">
+      ${lines.map((line) => `<li>${line}</li>`).join('')}
+    </ul>
+  `;
+}
+
+function renderFetchResult(label, result) {
+  const snippet = result.snippet
+    ? `<details><summary>Response snippet</summary><pre>${escapeHtml(result.snippet)}</pre></details>`
+    : '';
+  return `${label}: status ${result.status ?? 'n/a'} (${result.statusText ?? 'n/a'}), content-type ${
+    result.contentType ?? 'unknown'
+  }${snippet}`;
+}
+
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function renderErrorPanel(title, error) {
+  const suggestions = [];
+  if (error?.url && error.url.includes('://') && error.url.includes('/schemas/')) {
+    suggestions.push('Ensure the schema path is relative to the ui/ directory (../schemas/engine_output.schema.json).');
+  }
+  if (error?.contentType?.includes('text/html')) {
+    suggestions.push('HTML was returned instead of JSON. Confirm the URL is correct and not a 404 page.');
+    suggestions.push('GitHub Preview does not serve raw JSON. Use ui/dashboard_preview.html for PR previews.');
+  }
+  if (error?.status === 404) {
+    suggestions.push('Resource returned 404. Check that the file exists and that the server root is correct.');
+  }
+  if (!error?.status) {
+    suggestions.push('If viewing this file in GitHub Preview, open ui/dashboard_preview.html instead.');
+  }
+
+  const suggestionHtml = suggestions.length
+    ? `<ul>${suggestions.map((item) => `<li>${item}</li>`).join('')}</ul>`
+    : '<p>No automated suggestions available. Check network and file paths.</p>';
+
+  elements.status.innerHTML = `
+    <div class="error-panel">
+      <h2>${title}</h2>
+      <p><strong>URL:</strong> ${error?.url ?? 'n/a'}</p>
+      <p><strong>Status:</strong> ${error?.status ?? 'n/a'} ${error?.statusText ?? ''}</p>
+      <p><strong>Content-Type:</strong> ${error?.contentType ?? 'unknown'}</p>
+      ${error?.snippet ? `<pre>${escapeHtml(error.snippet)}</pre>` : ''}
+      <h3>Suggested fixes</h3>
+      ${suggestionHtml}
+    </div>
+  `;
+}
+
+function initializeValidator() {
+  if (!window.Ajv) {
+    updateStatus('Validation unavailable (Ajv missing).', false);
+    return null;
+  }
+  return new window.Ajv({ allErrors: true, strict: false });
+}
+
+function updateTrustSignals(payload) {
+  elements.schemaVersion.textContent = payload.schema_version || '—';
+  elements.runId.textContent = payload.run_id || '—';
+  elements.determinism.textContent =
+    payload.determinism && typeof payload.determinism.is_deterministic === 'boolean'
+      ? payload.determinism.is_deterministic
+        ? 'Deterministic'
+        : 'Non-deterministic'
+      : '—';
+  elements.markers.textContent = Array.isArray(payload.determinism?.markers)
+    ? payload.determinism.markers.join(', ') || 'None'
+    : '—';
+}
+
+function renderKeyValue(target, data) {
+  if (!data || typeof data !== 'object') {
+    target.innerHTML = '<p>No data.</p>';
+    return;
+  }
+  const items = Object.entries(data)
+    .map(([key, value]) => `<div class="kv"><strong>${key}</strong><div>${String(value)}</div></div>`)
+    .join('');
+  target.innerHTML = items || '<p>No data.</p>';
+}
+
+function renderErrors(errors) {
+  if (!errors || errors.length === 0) {
+    elements.errorList.innerHTML = '<li>No errors to report.</li>';
+    return;
+  }
+  elements.errorList.innerHTML = errors.map((error) => `<li>${escapeHtml(error.message ?? String(error))}</li>`).join('');
+}
+
+function renderMissingFields(errors) {
+  const missing = errors
+    .filter((error) => error.keyword === 'required')
+    .map((error) => error.params?.missingProperty)
+    .filter(Boolean);
+
+  if (missing.length === 0) {
+    elements.missingFields.innerHTML = '<li>No missing required fields.</li>';
+    return;
+  }
+  elements.missingFields.innerHTML = missing.map((field) => `<li>${escapeHtml(field)}</li>`).join('');
+}
+
+function renderPayload(payload) {
+  updateTrustSignals(payload);
+  renderKeyValue(elements.summary, payload.summary);
+  renderKeyValue(elements.metrics, payload.metrics);
+  renderKeyValue(elements.artifacts, payload.artifacts);
+}
+
+async function fetchWithDiagnostics(url) {
+  let response;
+  try {
+    response = await fetch(url);
+  } catch (error) {
+    return {
+      ok: false,
+      url: url.href,
+      status: null,
+      statusText: String(error),
+      contentType: null,
+      snippet: null,
+    };
+  }
+
+  const contentType = response.headers.get('content-type');
+  const text = await response.text();
+  const snippet = text.slice(0, 300);
+
+  return {
+    ok: response.ok,
+    url: response.url,
+    status: response.status,
+    statusText: response.statusText,
+    contentType,
+    snippet,
+    bodyText: text,
+  };
+}
+
+async function loadSchema() {
+  const result = await fetchWithDiagnostics(schemaUrl);
+  state.schemaFetchResult = result;
+  renderDiagnostics({ schemaFetch: result });
+  if (!result.ok) {
+    renderErrorPanel('Schema fetch failed', result);
+    return null;
+  }
+  if (result.contentType && result.contentType.includes('text/html')) {
+    renderErrorPanel('Schema fetch returned HTML', result);
+    return null;
+  }
+  try {
+    return JSON.parse(result.bodyText);
+  } catch (error) {
+    renderErrorPanel('Schema JSON parse failed', { ...result, statusText: String(error) });
+    return null;
+  }
+}
+
+async function loadPayload(url) {
+  const result = await fetchWithDiagnostics(url);
+  renderDiagnostics({ payloadFetch: result });
+  if (!result.ok) {
+    renderErrorPanel('Payload fetch failed', result);
+    return null;
+  }
+  if (result.contentType && result.contentType.includes('text/html')) {
+    renderErrorPanel('Payload fetch returned HTML', result);
+    return null;
+  }
+  try {
+    return JSON.parse(result.bodyText);
+  } catch (error) {
+    renderErrorPanel('Payload JSON parse failed', { ...result, statusText: String(error) });
+    return null;
+  }
+}
+
+async function validateAndRender(payload) {
+  if (!state.ajv || !state.schema) {
+    updateStatus('Schema validation unavailable.', false);
+    return;
+  }
+  const validate = state.ajv.compile(state.schema);
+  const valid = validate(payload);
+  updateStatus(valid ? 'Validation passed' : 'Validation failed', valid);
+  renderErrors(validate.errors || []);
+  renderMissingFields(validate.errors || []);
+  renderPayload(payload);
+}
+
+async function initialize() {
+  renderDiagnostics();
+  state.ajv = initializeValidator();
+  state.schema = await loadSchema();
+  if (!state.schema) {
+    return;
+  }
+  const payload = await loadPayload(payloadUrl);
+  if (!payload) {
+    return;
+  }
+  await validateAndRender(payload);
+}
+
+elements.loadSample.addEventListener('click', async () => {
+  const payload = await loadPayload(payloadUrl);
+  if (payload) {
+    await validateAndRender(payload);
+  }
+});
+
+elements.loadInvalid.addEventListener('click', async () => {
+  const payload = await loadPayload(invalidPayloadUrl);
+  if (payload) {
+    await validateAndRender(payload);
+  }
+});
+
+elements.payloadFile.addEventListener('change', async (event) => {
+  const file = event.target.files[0];
+  if (!file) {
+    return;
+  }
+  try {
+    const text = await file.text();
+    const payload = JSON.parse(text);
+    await validateAndRender(payload);
+  } catch (error) {
+    renderErrorPanel('Local payload parse failed', {
+      url: file.name,
+      statusText: String(error),
+      contentType: file.type,
+    });
+  }
+});
+
+window.addEventListener('error', (event) => {
+  renderErrorPanel('Unhandled error', {
+    url: event.filename,
+    statusText: event.message,
+  });
+});
+
+window.addEventListener('unhandledrejection', (event) => {
+  renderErrorPanel('Unhandled promise rejection', {
+    url: 'Promise rejection',
+    statusText: String(event.reason),
+  });
+});
+
+initialize();

--- a/ui/dashboard_preview.html
+++ b/ui/dashboard_preview.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Daily Dashboard (Preview)</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, Segoe UI, sans-serif;
+        background: #f6f7fb;
+        color: #18212f;
+      }
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 24px;
+      }
+      .banner {
+        background: #fff4e6;
+        border: 1px solid #f7b955;
+        padding: 12px;
+        border-radius: 8px;
+        margin-bottom: 16px;
+      }
+      .card {
+        background: #fff;
+        border-radius: 12px;
+        padding: 16px;
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+        margin-bottom: 16px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 16px;
+      }
+      .success {
+        color: #15803d;
+        font-weight: 700;
+      }
+      .failure {
+        color: #b91c1c;
+        font-weight: 700;
+      }
+      pre {
+        background: #f4f6fa;
+        padding: 12px;
+        border-radius: 8px;
+        overflow-x: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Daily Dashboard</h1>
+      <div class="banner">
+        Preview-safe mode (GitHub file preview). For real runs, use <code>ui/dashboard.html</code> over HTTP.
+      </div>
+      <section id="status" class="card">Loading preview payload…</section>
+      <section class="grid">
+        <div class="card">
+          <h2>Trust Signals</h2>
+          <ul>
+            <li><strong>Validation:</strong> <span id="validation">Pending</span></li>
+            <li><strong>Schema version:</strong> <span id="schemaVersion">—</span></li>
+            <li><strong>Run ID:</strong> <span id="runId">—</span></li>
+            <li><strong>Determinism:</strong> <span id="determinism">—</span></li>
+            <li><strong>Determinism markers:</strong> <span id="markers">—</span></li>
+          </ul>
+        </div>
+        <div class="card">
+          <h2>Summary</h2>
+          <div id="summary"></div>
+        </div>
+      </section>
+      <section class="grid">
+        <div class="card">
+          <h2>Metrics</h2>
+          <div id="metrics"></div>
+        </div>
+        <div class="card">
+          <h2>Artifacts</h2>
+          <div id="artifacts"></div>
+        </div>
+      </section>
+      <section class="card">
+        <h2>Embedded Payload</h2>
+        <pre id="payloadDump"></pre>
+      </section>
+    </main>
+
+    <script type="application/json" id="embedded-payload">
+    {
+      "schema_version": "1.0.0",
+      "run_id": "run-2026-01-01-0001",
+      "generated_at": "2026-01-01T21:59:00Z",
+      "determinism": {
+        "is_deterministic": true,
+        "markers": ["fixed_seed", "stable_hardware"]
+      },
+      "engine": {
+        "name": "DARK leaf drone",
+        "version": "4.1.0"
+      },
+      "summary": {
+        "status": "complete",
+        "score": 92.4,
+        "notes": "Nominal run with stable hover metrics."
+      },
+      "metrics": {
+        "energy_consumption": 12.8,
+        "hover_efficiency": 0.91,
+        "flight_time": 38.2
+      },
+      "artifacts": {
+        "report_path": "reports/run-2026-01-01-0001/report.json",
+        "metrics_path": "reports/run-2026-01-01-0001/metrics.json"
+      }
+    }
+    </script>
+    <script>
+      const payloadEl = document.getElementById('embedded-payload');
+      const statusEl = document.getElementById('status');
+      const payloadText = payloadEl.textContent.trim();
+
+      function renderKeyValue(targetId, data) {
+        const target = document.getElementById(targetId);
+        if (!data) {
+          target.textContent = 'No data.';
+          return;
+        }
+        target.innerHTML = Object.entries(data)
+          .map(([key, value]) => `<div><strong>${key}</strong>: ${String(value)}</div>`)
+          .join('');
+      }
+
+      try {
+        const payload = JSON.parse(payloadText);
+        document.getElementById('schemaVersion').textContent = payload.schema_version || '—';
+        document.getElementById('runId').textContent = payload.run_id || '—';
+        document.getElementById('determinism').textContent =
+          payload.determinism?.is_deterministic ? 'Deterministic' : 'Non-deterministic';
+        document.getElementById('markers').textContent = payload.determinism?.markers?.join(', ') || 'None';
+        document.getElementById('validation').textContent = 'PASS';
+        document.getElementById('validation').className = 'success';
+        renderKeyValue('summary', payload.summary);
+        renderKeyValue('metrics', payload.metrics);
+        renderKeyValue('artifacts', payload.artifacts);
+        document.getElementById('payloadDump').textContent = JSON.stringify(payload, null, 2);
+        statusEl.textContent = 'Preview payload rendered successfully (PASS).';
+        statusEl.className = 'card success';
+      } catch (error) {
+        statusEl.textContent = `Failed to parse embedded payload: ${error}`;
+        statusEl.className = 'card failure';
+      }
+    </script>
+  </body>
+</html>

--- a/ui/sample_payloads/invalid_engine_output.json
+++ b/ui/sample_payloads/invalid_engine_output.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1.0.0",
+  "generated_at": "2026-01-01T21:59:00Z",
+  "determinism": {
+    "is_deterministic": false,
+    "markers": []
+  },
+  "engine": {
+    "name": "DARK leaf drone"
+  },
+  "summary": {
+    "status": "incomplete",
+    "score": 10.1
+  },
+  "artifacts": {
+    "report_path": "reports/run-2026-01-01-0001/report.json"
+  }
+}

--- a/ui/sample_payloads/sample_engine_output.json
+++ b/ui/sample_payloads/sample_engine_output.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0.0",
+  "run_id": "run-2026-01-01-0001",
+  "generated_at": "2026-01-01T21:59:00Z",
+  "determinism": {
+    "is_deterministic": true,
+    "markers": ["fixed_seed", "stable_hardware"]
+  },
+  "engine": {
+    "name": "DARK leaf drone",
+    "version": "4.1.0"
+  },
+  "summary": {
+    "status": "complete",
+    "score": 92.4,
+    "notes": "Nominal run with stable hover metrics."
+  },
+  "metrics": {
+    "energy_consumption": 12.8,
+    "hover_efficiency": 0.91,
+    "flight_time": 38.2
+  },
+  "artifacts": {
+    "report_path": "reports/run-2026-01-01-0001/report.json",
+    "metrics_path": "reports/run-2026-01-01-0001/metrics.json"
+  }
+}


### PR DESCRIPTION
### Motivation
- Prevent the dashboard from rendering a blank page when viewed in GitHub file preview by providing a single-file, embedded-payload preview mode.
- Preserve full functionality for real hosts (local http.server and GitHub Pages) while surfacing clear, actionable diagnostics when fetches fail or HTML (404) is returned.
- Make onboarding and usage explicit in the UI docs so contributors know when to use preview vs real-host mode.

### Description
- Add `ui/dashboard_preview.html`, a single-file, preview-safe dashboard with inline CSS/JS and an embedded sample payload that renders immediately without any fetches.
- Harden `ui/dashboard.js` and `ui/dashboard.html` to compute a base URL from `window.location.href`, use relative asset URLs, print resolved schema/payload URLs in Diagnostics, detect HTML responses, and render an explanatory error panel that points users to `ui/dashboard_preview.html` for GitHub previews.
- Update `ui/README.md` with explicit instructions for GitHub preview vs local hosting and how to run the static server and CLI tooling.
- Include supporting resources: JSON schema `schemas/engine_output.schema.json`, CLI and static report renderer (`python/tools/*`), Python schema/locator helpers and unit tests under `python/tests`, and sample payloads under `ui/sample_payloads`.

### Testing
- Started a local static server with `python -m http.server 8000` and confirmed `schemas/engine_output.schema.json` and `ui/sample_payloads/sample_engine_output.json` responded `HTTP/1.0 200 OK` with `Content-type: application/json` via `curl -I` checks.
- Confirmed `ui/dashboard_preview.html` served `HTTP/1.0 200 OK` and captured a preview screenshot showing the embedded PASS view via an automated Playwright run.
- Attempted automated Playwright checks against `ui/dashboard.html` (real-host) but the headless Chromium run timed out/crashed, preventing a full screenshot/diagnostics capture for that path.
- Performed repository sanity checks (no tracked build artifacts matched) and committed the changes; unit test suite was added but not executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696bf7101234832aa1b302ed9bd1f9c4)